### PR TITLE
Allow SeleniumWebDriver to be derived from to use alternative RemoteWebDriver instances

### DIFF
--- a/src/Coypu/Drivers/Selenium/SeleniumWebDriver.cs
+++ b/src/Coypu/Drivers/Selenium/SeleniumWebDriver.cs
@@ -25,8 +25,13 @@ namespace Coypu.Drivers.Selenium
         private readonly OptionSelector optionSelector;
 
         public SeleniumWebDriver()
+            : this(new DriverFactory().NewRemoteWebDriver())
         {
-            selenium = new DriverFactory().NewRemoteWebDriver();
+        }
+
+        protected SeleniumWebDriver(RemoteWebDriver webDriver)
+        {
+            selenium = webDriver;
             scoping = new Scoping(selenium);
             elementFinder = new ElementFinder(scoping);
             fieldFinder = new FieldFinder(elementFinder);


### PR DESCRIPTION
I don't know how/if you're planning on doing headless browser support (it crosses the driver/browser split you've got), but this is a simple hook to allow clients to derive from SeleniumWebDriver and decide which WebDriver to use (e.g. I can create a SeleniumHtmlUnitWebDriver that simply calls the base constructor passing in new RemoteWebDriver(DesiredCapabilities.HtmlUnit))
