### PR TITLE
forceAllEvents when setting values using WATIN

### DIFF
--- a/src/Coypu.Drivers.Watin/WatiNDriver.cs
+++ b/src/Coypu.Drivers.Watin/WatiNDriver.cs
@@ -213,7 +213,14 @@ namespace Coypu.Drivers.Watin
             var textField = WatiNElement<TextField>(element);
             if (textField != null)
             {
-                textField.Value = value;
+                if (forceAllEvents)
+                {
+                    textField.TypeText(value);
+                }
+                else
+                {
+                    textField.Value = value;
+                }
                 return;
             }
             var fileUpload = WatiNElement<FileUpload>(element);


### PR DESCRIPTION
WATIN was not typing values into text fields, which was causing Knockout
to miss the update. If forceAllEvents is passed to the Set method, WATIN
will now TypeText into the field.
