### PR TITLE
WATIN respect forceAllEvents

### DIFF
--- a/src/Coypu.Drivers.Watin/WatiNDriver.cs
+++ b/src/Coypu.Drivers.Watin/WatiNDriver.cs
@@ -221,7 +221,14 @@ namespace Coypu.Drivers.Watin
             var textField = WatiNElement<TextField>(element);
             if (textField != null)
             {
-                textField.Value = value;
+                if (forceAllEvents)
+                {
+                    textField.TypeText(value);
+                }
+                else
+                {
+                    textField.Value = value;                    
+                }
                 return;
             }
             var fileUpload = WatiNElement<FileUpload>(element);


### PR DESCRIPTION
WATIN was not typing into fields when forceAllEvents was set to true.
Third time lucky on this pull request.
