### PR TITLE
Added support for PhantomJS and provided ability to pass explicit browser options through to Selenium webdriver implementations.

### DIFF
--- a/src/Coypu.Tests/When_interacting_with_the_browser/BrowserInteractionTests.cs
+++ b/src/Coypu.Tests/When_interacting_with_the_browser/BrowserInteractionTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Coypu.Drivers;
 using Coypu.Queries;
 using Coypu.Robustness;
 using Coypu.Tests.TestBuilders;
@@ -86,6 +87,11 @@ namespace Coypu.Tests.When_interacting_with_the_browser
         }
 
         public Driver NewWebDriver(Type driverType, Drivers.Browser browser)
+        {
+            return driver;
+        }
+
+        public Driver NewWebDriver(Type driverType, Browser browser, IDictionary<Browser, object> browserOptions)
         {
             return driver;
         }

--- a/src/Coypu/ActivatorDriverFactory.cs
+++ b/src/Coypu/ActivatorDriverFactory.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
+using Coypu.Drivers;
 
 namespace Coypu
 {
@@ -12,6 +14,27 @@ namespace Coypu
             try
             {
                 var driver = (Driver)Activator.CreateInstance(driverType, browser);
+                OpenDrivers++;
+                return driver;
+            }
+            catch (TargetInvocationException e)
+            {
+                throw e.InnerException;
+            }
+        }
+
+        public Driver NewWebDriver(Type driverType, Drivers.Browser browser, IDictionary<Browser, object> browserOptions)
+        {
+            // Look for constructor on target driver type that accepts browserOptions argument
+            var constructor = driverType.GetConstructor(new Type[] { typeof(Type), typeof(Browser), typeof(IDictionary<Browser, object>) });
+
+            // If no matching constructor exists, use other factory method
+            if (constructor == null)
+                return NewWebDriver(driverType, browser);
+
+            try
+            {
+                var driver = (Driver)Activator.CreateInstance(driverType, browser, browserOptions);
                 OpenDrivers++;
                 return driver;
             }

--- a/src/Coypu/BrowserSession.cs
+++ b/src/Coypu/BrowserSession.cs
@@ -24,11 +24,11 @@ namespace Coypu
         /// <summary>
         /// A new browser session. Control the lifecycle of this session with using{} / session.Dispose()
         /// </summary>
-        /// <param name="SessionConfigurationconfiguration for this session</param>
+        /// <param name="sessionConfiguration">Configuration for this session</param>
         /// <returns>The new session</returns>
-        public BrowserSession(SessionConfiguration SessionConfiguration)
+        public BrowserSession(SessionConfiguration sessionConfiguration)
             : this(new ActivatorDriverFactory(),
-                   SessionConfiguration,
+                   sessionConfiguration,
                    new RetryUntilTimeoutRobustWrapper(),
                    new StopwatchWaiter(),
                    new WebClientWithCookies(),
@@ -36,8 +36,8 @@ namespace Coypu
         {
         }
 
-        internal BrowserSession(DriverFactory driver, SessionConfiguration SessionConfiguration, RobustWrapper robustWrapper, Waiter waiter, RestrictedResourceDownloader restrictedResourceDownloader, UrlBuilder urlBuilder)
-            : base(SessionConfiguration, null, driver.NewWebDriver(SessionConfiguration.Driver, SessionConfiguration.Browser), robustWrapper, waiter, urlBuilder)
+        internal BrowserSession(DriverFactory driver, SessionConfiguration sessionConfiguration, RobustWrapper robustWrapper, Waiter waiter, RestrictedResourceDownloader restrictedResourceDownloader, UrlBuilder urlBuilder)
+            : base(sessionConfiguration, null, driver.NewWebDriver(sessionConfiguration.Driver, sessionConfiguration.Browser, sessionConfiguration.BrowserOptions), robustWrapper, waiter, urlBuilder)
         {
             this.restrictedResourceDownloader = restrictedResourceDownloader;
         }

--- a/src/Coypu/DriverFactory.cs
+++ b/src/Coypu/DriverFactory.cs
@@ -1,9 +1,26 @@
 using System;
+using System.Collections.Generic;
+using Coypu.Drivers;
 
 namespace Coypu
 {
     public interface DriverFactory
     {
+        /// <summary>
+        /// Creates a new web driver using the specified driver type, browser and browser options.
+        /// </summary>
+        /// <param name="driverType">The <see cref="Type"/> of the web driver.</param>
+        /// <param name="browser">The type of browser to be driven by the web driver.</param>
+        /// <returns>The newly initialized instance of a <see cref="Driver"/> implementation.</returns>
         Driver NewWebDriver(Type driverType, Drivers.Browser browser);
+
+        /// <summary>
+        /// Creates a new web driver using the specified driver type, browser and browser options.
+        /// </summary>
+        /// <param name="driverType">The <see cref="Type"/> of the web driver.</param>
+        /// <param name="browser">The type of browser to be driven by the web driver.</param>
+        /// <param name="browserOptions">A dictionary of native browser-specific options for the various types of browsers.</param>
+        /// <returns>The newly initialized instance of a <see cref="Driver"/> implementation.</returns>
+        Driver NewWebDriver(Type driverType, Browser browser, IDictionary<Browser, object> browserOptions);
     }
 }

--- a/src/Coypu/Drivers/Browser.cs
+++ b/src/Coypu/Drivers/Browser.cs
@@ -21,6 +21,7 @@ namespace Coypu.Drivers
         public static Browser Android                = new Browser { Javascript = true };
         public static Browser HtmlUnit               = new Browser { Javascript = true };
         public static Browser HtmlUnitWithJavaScript = new Browser { Javascript = false };
+        public static Browser PhantomJS              = new Browser { Javascript = true };
 
         public static Browser Parse(string browserName)
         {

--- a/src/Coypu/Drivers/Selenium/DriverFactory.cs
+++ b/src/Coypu/Drivers/Selenium/DriverFactory.cs
@@ -1,25 +1,51 @@
 using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Firefox;
 using OpenQA.Selenium.IE;
 using OpenQA.Selenium.Android;
+using OpenQA.Selenium.PhantomJS;
 using OpenQA.Selenium.Remote;
 
 namespace Coypu.Drivers.Selenium
 {
     internal class DriverFactory
     {
-        public IWebDriver NewWebDriver(Browser browser)  {
+        public IWebDriver NewWebDriver(Browser browser) {
+            return NewWebDriver(browser, new Dictionary<Browser, object>());
+        }
+
+        public IWebDriver NewWebDriver(Browser browser, IDictionary<Browser, object> browserOptions)  {
             if (browser == Browser.Firefox)
                 return new FirefoxDriver();
             if (browser == Browser.InternetExplorer)
             {
-                var options = new InternetExplorerOptions
+                InternetExplorerOptions options;
+
+                if (browserOptions.ContainsKey(Browser.InternetExplorer))
+                {
+                    options = browserOptions[Browser.InternetExplorer] as InternetExplorerOptions;
+
+                    // Make sure options provided are of the expected type for Internet Explorer
+                    if (options == null)
                     {
-                        IntroduceInstabilityByIgnoringProtectedModeSettings = true,
-                        EnableNativeEvents = true
-                    };
+                        throw new ArgumentException(
+                            "Options object provided for Internet Explorer was not the expected type (Selenium's InternetExplorerOptions).");
+                    }
+                }
+                else
+                {
+                    // Default options
+                    options = new InternetExplorerOptions
+                                  {
+                                      IntroduceInstabilityByIgnoringProtectedModeSettings = true,
+                                      EnableNativeEvents = true
+                                  };
+                }
+
                 return new InternetExplorerDriver(options);
             }
             if (browser == Browser.Chrome)
@@ -33,7 +59,53 @@ namespace Coypu.Drivers.Selenium
                 desiredCapabilities.IsJavaScriptEnabled = true;
                 return new RemoteWebDriver(desiredCapabilities);
             }
+            if (browser == Browser.PhantomJS)
+                return GetPhantomJSDriver(browserOptions);
+
             return browserNotSupported(browser,null);
+        }
+
+        private static IWebDriver GetPhantomJSDriver(IDictionary<Browser, object> browserOptions)
+        {
+            if (browserOptions.ContainsKey(Browser.PhantomJS))
+            {
+                // Try processing options as pre-initialized PhantomJSDriverService from Selenium
+                var driverService = browserOptions[Browser.PhantomJS] as PhantomJSDriverService;
+
+                // PhantomJSDriverService was not provided?
+                if (driverService == null)
+                {
+                    // Try processing options as JSON configuration for PhantomJS
+                    string jsonOptions = browserOptions[Browser.PhantomJS] as string;
+
+                    if (jsonOptions != null)
+                    {
+                        try
+                        {
+                            // Try deserializing JSON into a default driver service instance
+                            driverService = JsonConvert.DeserializeObject<PhantomJSDriverService>(jsonOptions);
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new SerializationException(
+                                "Unable to deserialize the string value supplied as the browser options for PhantomJS into a PhantomJSDriverService instance.  Please review the PhantomJS documentation for JSON configuration, or serialize an instance of a PhantomJSDriverService instance.",
+                                ex);
+                        }
+                    }
+                }
+
+                // Make sure options provided are of the expected type for PhantomJS
+                if (driverService == null)
+                {
+                    throw new ArgumentException(
+                        "The browser options provided for PhantomJS were not the expected type (Selenium's PhantomJSDriverService, or a JSON string containing the configuration, as specified in the PhantomJS command-line arguments documentation).");
+                }
+
+                return new PhantomJSDriver(driverService);
+            }
+
+            // Default to PhantomJS with no specific options
+            return new PhantomJSDriver();
         }
 
         private IWebDriver browserNotSupported(Browser browser, Exception inner) {

--- a/src/Coypu/Drivers/Selenium/SeleniumWebDriver.cs
+++ b/src/Coypu/Drivers/Selenium/SeleniumWebDriver.cs
@@ -28,6 +28,12 @@ namespace Coypu.Drivers.Selenium
         public SeleniumWebDriver(Browser browser)
             : this(new DriverFactory().NewWebDriver(browser),  browser)
         {
+            
+        }
+
+        public SeleniumWebDriver(Browser browser, IDictionary<Browser, object> browserOptions)
+            : this(new DriverFactory().NewWebDriver(browser, browserOptions), browser)
+        {
         }
 
         protected SeleniumWebDriver(IWebDriver webDriver, Browser browser)

--- a/src/Coypu/SessionConfiguration.cs
+++ b/src/Coypu/SessionConfiguration.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using Coypu.Drivers;
 using Coypu.Drivers.Selenium;
 
 namespace Coypu
@@ -23,6 +25,7 @@ namespace Coypu
             SSL = false;
             Browser = Drivers.Browser.Firefox;
             Driver = typeof (SeleniumWebDriver);
+            BrowserOptions = new Dictionary<Browser, object>();
         }
 
         /// <summary>
@@ -30,6 +33,15 @@ namespace Coypu
         /// <para>Default: Firefox</para>
         /// </summary>
         public Drivers.Browser Browser { get; set; }
+
+        /// <summary>
+        /// Specifies the native options for supported browsers (native options objects keyed by <see cref="Browser"/>).
+        /// </summary>
+        /// <remarks>This mechanism allows you to supply options for native browser types that are specific to the
+        /// driver implementation to be used.  For example, Selenium provides "options" classes for some of the supported
+        /// browser types (e.g. ChromeOptions, InternetExplorerOptions, PhantomJSOptions).  Adding them to this 
+        /// dictionary will make them available to the SeleniumWebDriver implementations.</remarks>
+        public IDictionary<Browser, object> BrowserOptions { get; set; }
 
         /// <summary>
         /// <para>Specifies the driver you would like to use to control the browser</para> 
@@ -59,6 +71,5 @@ namespace Coypu
         /// <para>Default: false</para>
         /// </summary>
         public bool SSL { get; set; }
-
     }
 }


### PR DESCRIPTION
This pull request is related to a pull request (https://github.com/SeleniumHQ/selenium/pull/13) I've just submitted to SeleniumHQ to allow passing of browser-specific options through to the drivers, and specifically for the purpose of ignoring SSL errors when launching PhantomJS.exe.

I'm submitting this pull request in the hopes of starting a conversation around how to be able to explicitly pass such browser-specific options through Coypu to Selenium.
