### PR TITLE
Improve Selenium dependency

### DIFF
--- a/Coypu.nuspec
+++ b/Coypu.nuspec
@@ -11,8 +11,8 @@
     <description>Intuitive, robust browser automation for .Net</description>
     <tags></tags>
     <dependencies>
-      <dependency id="Selenium.WebDriver" version="[2.35.0, 3.0)" />
-      <dependency id="Selenium.Support" version="[2.35.0, 3.0)" />
+      <dependency id="Selenium.WebDriver" version="[2.37.0]" />
+      <dependency id="Selenium.Support" version="[2.37.0]" />
     </dependencies>
   </metadata>
     <files>


### PR DESCRIPTION
Selenium.WebDriver 2.37 is out and Coypu is "out-of-date" with regards to the dependency.

Do you see a problem with loosening up on the dependency? My change is now >= 2.35.0 && < 3.0.
