### PR TITLE
Performance issue with IE 64 bit driver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ WebDriver is generally stable with the last but one release of FireFox in my exp
 
 ###### Internet Explorer
 
-You will need the new standalone InternetExplorerDriver.exe in your PATH or in the bin of your test project. [Download from google code](http://code.google.com/p/selenium/wiki/InternetExplorerDriver)
+You will need the new standalone InternetExplorerDriver.exe in your PATH or in the bin of your test project. [Download from google code](http://code.google.com/p/selenium/wiki/InternetExplorerDriver) (Know serious performance issue with IE 64 bit driver, use 32 bit version if possible.)
 
 Only IE9 supports CSS & XPath and certain HTML features. The WatiN driver is notably faster in IE than the WebDriver IE driver, so is recommended for testing in Internet Explorer. The WatiN driver comes in a seperate package (see below).
 


### PR DESCRIPTION
Fillin method is super slow when using IE 64 bit driver.
The reason for this seem to be that the Fillin method is using selenium's sendkeys method. This method is for some reason very slow when using the 64 bit driver. Going from ca 5 sek pr char to almost instant. However the SeleniumBackedWebDriver have a method called Type(). This method runs fast even with the 64 bit driver for some reason.
