### PR TITLE
Parameterized BrowserSession to take in a Driver.  Overloaded the intern...

### DIFF
--- a/src/Coypu.Tests/TestBuilders/TestSessionBuilder.cs
+++ b/src/Coypu.Tests/TestBuilders/TestSessionBuilder.cs
@@ -6,12 +6,23 @@ namespace Coypu.Tests.TestBuilders
 {
     internal class TestSessionBuilder
     {
-        internal static BrowserSession Build(SessionConfiguration SessionConfiguration, Driver driver, TimingStrategy timingStrategy, Waiter waiter,
-                                      RestrictedResourceDownloader restrictedResourceDownloader, UrlBuilder urlBuilder, DisambiguationStrategy disambiguationStrategy = null)
-
+        internal static BrowserSession Build(SessionConfiguration sessionConfiguration, 
+                                                Driver driver, 
+                                                TimingStrategy timingStrategy, 
+                                                Waiter waiter,
+                                                RestrictedResourceDownloader restrictedResourceDownloader, 
+                                                UrlBuilder urlBuilder, 
+                                                DisambiguationStrategy disambiguationStrategy = null)
         {
             disambiguationStrategy = disambiguationStrategy ?? new FirstOrDefaultNoDisambiguationStrategy();
-            return new BrowserSession(new StubDriverFactory(driver), SessionConfiguration, timingStrategy, waiter, restrictedResourceDownloader, urlBuilder, disambiguationStrategy);
+            
+            return new BrowserSession(sessionConfiguration, 
+                            new StubDriverFactory(driver), 
+                            timingStrategy, 
+                            waiter, 
+                            urlBuilder, 
+                            disambiguationStrategy,
+                            restrictedResourceDownloader);
         }
     }
 }

--- a/src/Coypu/BrowserSession.cs
+++ b/src/Coypu/BrowserSession.cs
@@ -18,32 +18,95 @@ namespace Coypu
         /// A new browser session. Control the lifecycle of this session with using{} / session.Dispose()
         /// </summary>
         /// <returns>The new session with default configuration </returns>
-        public BrowserSession() : this(new SessionConfiguration())
+        public BrowserSession()
+            : this(new SessionConfiguration())
         {
         }
 
         /// <summary>
         /// A new browser session. Control the lifecycle of this session with using{} / session.Dispose()
         /// </summary>
-        /// <param name="SessionConfigurationconfiguration for this session</param>
+        /// <param name="sessionConfiguration">configuration for this session</param>
         /// <returns>The new session</returns>
-        public BrowserSession(SessionConfiguration SessionConfiguration)
-            : this(new ActivatorDriverFactory(),
-                   SessionConfiguration,
-                   new RetryUntilTimeoutTimingStrategy(),
-                   new StopwatchWaiter(),
-                   new WebClientWithCookies(),
-                   new FullyQualifiedUrlBuilder(),
-                   new FinderOptionsDisambiguationStrategy())
+        public BrowserSession(SessionConfiguration sessionConfiguration)
+            : this(
+                sessionConfiguration,
+                new ActivatorDriverFactory(),
+                new RetryUntilTimeoutTimingStrategy(),
+                new StopwatchWaiter(),
+                new FullyQualifiedUrlBuilder(),
+                new FinderOptionsDisambiguationStrategy(),
+                new WebClientWithCookies()
+            )
         {
         }
 
-        internal BrowserSession(DriverFactory driverFactory, SessionConfiguration SessionConfiguration, TimingStrategy timingStrategy, Waiter waiter, RestrictedResourceDownloader restrictedResourceDownloader, UrlBuilder urlBuilder, DisambiguationStrategy disambiguationStrategy)
-            : base(SessionConfiguration, null, driverFactory.NewWebDriver(SessionConfiguration.Driver, SessionConfiguration.Browser), timingStrategy, waiter, urlBuilder, disambiguationStrategy)
+        /// <summary>
+        /// A new browser session with defined driver.  
+        /// Replaces sessionConfiguration driver.
+        /// </summary>
+        /// <param name="sessionConfiguration"></param>
+        /// <param name="driver"></param>
+        public BrowserSession(SessionConfiguration sessionConfiguration, Driver driver)
+            : this(
+                sessionConfiguration,
+                driver,
+                new RetryUntilTimeoutTimingStrategy(),
+                new StopwatchWaiter(),
+                new FullyQualifiedUrlBuilder(),
+                new FinderOptionsDisambiguationStrategy(),
+                new WebClientWithCookies()
+                )
+        {
+        }
+
+        internal BrowserSession(
+            SessionConfiguration sessionConfiguration,
+            DriverFactory driverFactory,
+            TimingStrategy timingStrategy,
+            Waiter waiter,
+            UrlBuilder urlBuilder,
+            DisambiguationStrategy disambiguationStrategy,
+            RestrictedResourceDownloader restrictedResourceDownloader
+            )
+            : base(
+               sessionConfiguration,
+               null,
+               driverFactory.NewWebDriver(sessionConfiguration.Driver, sessionConfiguration.Browser),
+               timingStrategy,
+               waiter,
+               urlBuilder,
+               disambiguationStrategy
+                )
         {
             this.restrictedResourceDownloader = restrictedResourceDownloader;
         }
 
+        internal BrowserSession(
+            SessionConfiguration sessionConfiguration,
+            Driver driver,
+            TimingStrategy timingStrategy,
+            Waiter waiter,
+            UrlBuilder urlBuilder,
+            DisambiguationStrategy disambiguationStrategy,
+            RestrictedResourceDownloader restrictedResourceDownloader
+            )
+            : base(
+              sessionConfiguration,
+              null,
+              driver,
+              timingStrategy,
+              waiter,
+              urlBuilder,
+              disambiguationStrategy
+                )
+        {
+            this.restrictedResourceDownloader = restrictedResourceDownloader;
+        }
+
+        /// <summary>
+        /// Access to grand-parent DriverScope's driver.
+        /// </summary>
         public Driver Driver
         {
             get { return driver; }


### PR DESCRIPTION
...al constructor to just take in  a Driver instead of a DriverFactory.  Reordered the parameters to be consistent.  Added some XML comments because R# was bugging me about it.  Added Test in ApiExamples @ the bottom.  TestSessionbuilder used the constructor that I re-ordered.  Re-ordered its parameters.

I also renamed some variables to fit the naming convention that R# likes.
