### PR TITLE
Added generic ExecuteScript() method to the Driver interface

### DIFF
--- a/src/Coypu.Drivers.Watin/WatiNDriver.cs
+++ b/src/Coypu.Drivers.Watin/WatiNDriver.cs
@@ -106,6 +106,11 @@ namespace Coypu.Drivers.Watin
             return retval;
         }
 
+        public T ExecuteScript<T> (string javascript, Scope scope) where T : class
+        {
+            throw new NotSupportedException ("WatiN supports string return objects from JavaScript scripts only.");
+        }
+
         public void Hover(Element element)
         {
             WatiNElement(element).FireEvent("onmouseover");

--- a/src/Coypu.Tests/TestDoubles/FakeDriver.cs
+++ b/src/Coypu.Tests/TestDoubles/FakeDriver.cs
@@ -168,6 +168,11 @@ namespace Coypu.Tests.TestDoubles
             return Find<string>(stubbedExecuteScriptResults, javascript, scope);
         }
 
+        public T ExecuteScript<T> (string javascript, Scope scope) where T : class
+        {
+          return Find<T> (stubbedExecuteScriptResults, javascript, scope);
+        }
+
         public IEnumerable<ElementFound> FindFrames(string locator, Scope scope, Options options)
         {
             return Find<IEnumerable<ElementFound>>(stubbedFrames, locator, scope, options);

--- a/src/Coypu.Tests/TestDoubles/StubDriver.cs
+++ b/src/Coypu.Tests/TestDoubles/StubDriver.cs
@@ -118,6 +118,11 @@ namespace Coypu.Tests.TestDoubles
             return null;
         }
 
+        public T ExecuteScript<T> (string javascript, Scope scope) where T : class
+        {
+          return null;
+        }
+
         public ElementFound FindIFrame(string locator, Scope scope)
         {
             return null;

--- a/src/Coypu/BrowserWindow.cs
+++ b/src/Coypu/BrowserWindow.cs
@@ -98,10 +98,20 @@ namespace Coypu
         /// Executes custom javascript in the browser
         /// </summary>
         /// <param name="javascript">JavaScript to execute</param>
-        /// <returns>Anything returned from the script</returns>
+        /// <returns>string returned from the script</returns>
         public string ExecuteScript(string javascript) 
         {
             return driver.ExecuteScript(javascript, this);
+        }
+
+        /// <summary>
+        /// Executes custom javascript in the browser
+        /// </summary>
+        /// <param name="javascript">JavaScript to execute</param>
+        /// <returns>Anything returned from the script</returns>
+        public T ExecuteScript<T>(string javascript) where T : class
+        {
+            return driver.ExecuteScript<T>(javascript, this);
         }
 
         /// <summary>

--- a/src/Coypu/Driver.cs
+++ b/src/Coypu/Driver.cs
@@ -18,6 +18,7 @@ namespace Coypu
         Uri Location(Scope scope);
         String Title(Scope scope);
         string ExecuteScript(string javascript, Scope scope);
+        T ExecuteScript<T> (string javascript, Scope scope) where T : class;
         IEnumerable<Cookie> GetBrowserCookies();
         void Click(Element element);
         void AcceptModalDialog(Scope scope);

--- a/src/Coypu/Drivers/Selenium/SeleniumWebDriver.cs
+++ b/src/Coypu/Drivers/Selenium/SeleniumWebDriver.cs
@@ -244,6 +244,19 @@ namespace Coypu.Drivers.Selenium
             return result == null ? null : result.ToString();
         }
 
+        public T ExecuteScript<T> (string javascript, Scope scope) where T : class
+        {
+          if (NoJavascript)
+                throw new NotSupportedException("Javascript is not supported by " + browser);
+
+          elementFinder.SeleniumScope(scope);
+          var result = JavaScriptExecutor.ExecuteScript(javascript);
+          if (result == null)
+            return null;
+
+          return (T) result;
+        }
+
         private string NormalizeCRLFBetweenBrowserImplementations(string text)
         {
             if (webDriver is ChromeDriver) // Which adds extra whitespace around CRLF


### PR DESCRIPTION
Added generic ExecuteScript() method to the Driver interface, returning the result from the JavaScript script as type T. Added to public BrowserWindow API as well.

See https://github.com/featurist/coypu/issues/109 for more information.
