### PR TITLE
Make the second constructor public on SeleniumWebDriver to allow the …

### DIFF
--- a/src/Coypu/Drivers/Selenium/SeleniumWebDriver.cs
+++ b/src/Coypu/Drivers/Selenium/SeleniumWebDriver.cs
@@ -28,7 +28,7 @@ namespace Coypu.Drivers.Selenium
         {
         }
 
-        protected SeleniumWebDriver(IWebDriver webDriver, Browser browser)
+        public SeleniumWebDriver(IWebDriver webDriver, Browser browser)
         {
             this.webDriver = webDriver;
             this.browser = browser;


### PR DESCRIPTION
…driver to be provided.

In my particular case, I needed to tame the logging to the console for the PhantomJs browser by providing the command line argument.  The existing constructor instantiates the PhantomJSDriver before I can get the parameter to it.

Open to other solutions - I appreciate this opens up some implementation you may not want to expose at this level.

```
// check for Phantom JS and if we are using that browser, tone down the logging
// into the console

var driverService = PhantomJSDriverService.CreateDefaultService();
driverService.AddArgument("--webdriver-loglevel=ERROR");

var driver = new PhantomJSDriver(driverService);

var browser = Browser.PhantomJS;
**var seleniumDriver = new SeleniumWebDriver(driver, browser);**

return new BrowserSession(sessionConfiguration, seleniumDriver);
```
