### PR TITLE
Firefox hover fix

### DIFF
--- a/src/Coypu/Actions/Hover.cs
+++ b/src/Coypu/Actions/Hover.cs
@@ -15,13 +15,6 @@ namespace Coypu.Actions
         public override void Act()
         {
             var element = driverScope.Now();
-
-            // In Firefox, scrolling to an element in firefox is broken.
-            // Bug: https://github.com/mozilla/geckodriver/issues/901
-            if (driverScope.Browser == Browser.Firefox)
-            {
-                Driver.ExecuteScript("window.scrollTo(0, document.body.scrollHeight);", driverScope);
-            }
             Driver.Hover(element);
         }
     }


### PR DESCRIPTION
The bug in question has been fixed as of Firefox 59.0, so the workaround can be removed.