### PR TITLE
Fix Firefox/IFrame Behaviour + General maintenance 

### DIFF
--- a/src/Coypu.AcceptanceTests/Coypu.AcceptanceTests.csproj
+++ b/src/Coypu.AcceptanceTests/Coypu.AcceptanceTests.csproj
@@ -10,11 +10,13 @@
     <DebugType>full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="2.44.0" />
-    <PackageReference Include="Selenium.WebDriver.GeckoDriver.Win64" Version="0.23.0" />
-    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="3.141.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="75.0.3770.90" />
+    <PackageReference Include="Selenium.WebDriver.GeckoDriver.Win64" Version="0.24.0" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="3.141.59" />
     <PackageReference Include="SelfishHttp" Version="0.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Coypu.Drivers.Tests/Coypu.Drivers.Tests.csproj
+++ b/src/Coypu.Drivers.Tests/Coypu.Drivers.Tests.csproj
@@ -9,9 +9,11 @@
   </PropertyGroup>
   <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="2.44.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="75.0.3770.90" />
     <PackageReference Include="SelfishHttp" Version="0.3.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>

--- a/src/Coypu.Drivers.Tests/Coypu.Drivers.Tests.csproj
+++ b/src/Coypu.Drivers.Tests/Coypu.Drivers.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="75.0.3770.90" />
+    <PackageReference Include="Selenium.WebDriver.GeckoDriver.Win64" Version="0.24.0" />
     <PackageReference Include="SelfishHttp" Version="0.3.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>

--- a/src/Coypu.Drivers.Tests/DriverSpecs.cs
+++ b/src/Coypu.Drivers.Tests/DriverSpecs.cs
@@ -48,7 +48,7 @@ namespace Coypu.Drivers.Tests
                                                                                          TextPrecision = TextPrecision.Exact
                                                                                      };
 
-        protected static readonly DisambiguationStrategy DisambiguationStrategy = new ThrowsWhenMissingButNoDisambiguationStrategy();
+        protected static readonly DisambiguationStrategy DisambiguationStrategy = new FinderOptionsDisambiguationStrategy();
 
         public static IDriver Driver
         {

--- a/src/Coypu.Drivers.Tests/DriverSpecs.cs
+++ b/src/Coypu.Drivers.Tests/DriverSpecs.cs
@@ -48,7 +48,7 @@ namespace Coypu.Drivers.Tests
                                                                                          TextPrecision = TextPrecision.Exact
                                                                                      };
 
-        protected static readonly DisambiguationStrategy DisambiguationStrategy = new FinderOptionsDisambiguationStrategy();
+        protected static readonly DisambiguationStrategy DisambiguationStrategy = new ThrowsWhenMissingButNoDisambiguationStrategy();
 
         public static IDriver Driver
         {

--- a/src/Coypu.Drivers.Tests/When_getting_cookies.cs
+++ b/src/Coypu.Drivers.Tests/When_getting_cookies.cs
@@ -73,7 +73,7 @@ namespace Coypu.Drivers.Tests
             var cookies = Driver.Cookies.GetAll()
                 .ToArray();
 
-            StringAssert.StartsWith(cookies.First(c => c.Name == "cookie1").Path, "/resource");
+            StringAssert.StartsWith("/resource", cookies.First(c => c.Name == "cookie1").Path);
         }
     }
 }

--- a/src/Coypu.Drivers.Tests/When_getting_cookies.cs
+++ b/src/Coypu.Drivers.Tests/When_getting_cookies.cs
@@ -19,14 +19,14 @@ namespace Coypu.Drivers.Tests
             Driver.ExecuteScript("document.cookie = 'cookie2=value2; '", Root);
 
             var cookies = Driver.Cookies.GetAll()
-                                .ToArray();
+                .ToArray();
 
             Assert.That(cookies.First(c => c.Name == "cookie1")
-                               .Value,
-                        Is.EqualTo("value1"));
+                    .Value,
+                Is.EqualTo("value1"));
             Assert.That(cookies.First(c => c.Name == "cookie2")
-                               .Value,
-                        Is.EqualTo("value2"));
+                    .Value,
+                Is.EqualTo("value2"));
         }
 
         [Test]
@@ -39,14 +39,14 @@ namespace Coypu.Drivers.Tests
 
 
             var cookies = Driver.Cookies.GetAll()
-                                .ToArray();
+                .ToArray();
 
             Assert.That(cookies.First(c => c.Name == "cookie1")
-                               .Value,
-                        Is.EqualTo("value11"));
+                    .Value,
+                Is.EqualTo("value11"));
             Assert.That(cookies.First(c => c.Name == "cookie2")
-                               .Value,
-                        Is.EqualTo("value22"));
+                    .Value,
+                Is.EqualTo("value22"));
         }
 
         [Test]
@@ -71,11 +71,9 @@ namespace Coypu.Drivers.Tests
             Driver.ExecuteScript("document.cookie = 'cookie1=value1; path=/resource'", Root);
 
             var cookies = Driver.Cookies.GetAll()
-                                .ToArray();
+                .ToArray();
 
-            Assert.That(cookies.First(c => c.Name == "cookie1")
-                               .Path,
-                        Is.EqualTo("/resource"));
+            StringAssert.StartsWith(cookies.First(c => c.Name == "cookie1").Path, "/resource");
         }
     }
 }

--- a/src/Coypu.Drivers.Tests/When_hovering.cs
+++ b/src/Coypu.Drivers.Tests/When_hovering.cs
@@ -5,9 +5,9 @@ namespace Coypu.Drivers.Tests
 {
     public class When_hovering : DriverSpecs
     {
+        //Broken in firefox & edge due to the driver not scrolling when moving to an element
         [Test]
         public void Mouses_over_the_underlying_element()
-
         {
             var element = Id("hoverOnMeTest");
             element.Text.ShouldBe("Hover on me");

--- a/src/Coypu.NUnit/Coypu.NUnit.csproj
+++ b/src/Coypu.NUnit/Coypu.NUnit.csproj
@@ -38,7 +38,7 @@ Supported platforms:
     <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="[3.11.0,4)" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Coypu\Coypu.csproj" Version="[3.0.0,4)" />

--- a/src/Coypu.NUnit/Coypu.NUnit.csproj
+++ b/src/Coypu.NUnit/Coypu.NUnit.csproj
@@ -5,24 +5,17 @@
     <BuildPackage>true</BuildPackage>
     <AssemblyTitle>Coypu.NUnit</AssemblyTitle>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.1.0</FileVersion>
+    <FileVersion>3.1.0.0</FileVersion>
     <PackageId>Coypu.NUnit</PackageId>
-    <Version>3.0.1</Version>
-    <Description>NUnit matchers for Coypu.
-
-Supported platforms:
-- .NET Framework 4.5+
-- .NET Standard 2.0+
-- .NET Core 2.0</Description>
-    <PackageLicenseUrl>https://github.com/featurist/coypu/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <Version>3.1.0-rc</Version>
+    <Description>NUnit matchers for Coypu.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/featurist/coypu/</PackageProjectUrl>
     <Copyright>Copyright © 2018 Adrian Longley and Contributors</Copyright>
     <PackageTags>browser, automation, selenium, testing, nunit</PackageTags>
     <LangVersion>7.3</LangVersion>
     <Authors>Adrian Longley, Jakub Obstarczyk</Authors>
     <Company>Coypu</Company>
-    <Product />
-    <PackageReleaseNotes>nuget package build from csproj</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/featurist/coypu</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>
@@ -41,6 +34,6 @@ Supported platforms:
     <PackageReference Include="NUnit" Version="3.12.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Coypu\Coypu.csproj" Version="[3.0.0,4)" />
+    <ProjectReference Include="..\Coypu\Coypu.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Coypu.NUnit/Coypu.NUnit.csproj
+++ b/src/Coypu.NUnit/Coypu.NUnit.csproj
@@ -31,7 +31,7 @@
     <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="[3.12.0,4)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Coypu\Coypu.csproj" />

--- a/src/Coypu.Tests/Coypu.Tests.csproj
+++ b/src/Coypu.Tests/Coypu.Tests.csproj
@@ -8,7 +8,9 @@
     <DebugType>full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Coypu\Coypu.csproj" />

--- a/src/Coypu.Tests/When_making_browser_interactions_robust/TestQueries.cs
+++ b/src/Coypu.Tests/When_making_browser_interactions_robust/TestQueries.cs
@@ -8,7 +8,6 @@ namespace Coypu.Tests.When_making_browser_interactions_robust
     {
         private readonly Stopwatch stopWatch = new Stopwatch();
         private readonly bool actualResult;
-        private readonly bool expecting;
 
         public int Tries { get; set; }
         public long LastCall { get; set; }
@@ -28,10 +27,6 @@ namespace Coypu.Tests.When_making_browser_interactions_robust
             return actualResult;
         }
 
-        public bool ExpectedResult
-        {
-            get { return expecting; }
-        }
     }
 
     public class AlwaysSucceedsQuery<T> : Query<T>
@@ -66,10 +61,7 @@ namespace Coypu.Tests.When_making_browser_interactions_robust
             return actualResult;
         }
 
-        public object ExpectedResult
-        {
-            get { return expecting; }
-        }
+        public object ExpectedResult => expecting;
     }
 
     public class ThrowsSecondTimeQuery<T> : Query<T>
@@ -77,7 +69,6 @@ namespace Coypu.Tests.When_making_browser_interactions_robust
         public Options Options { get; set; }
         public DriverScope Scope { get; private set; }
         private readonly T result;
-        private readonly TimeSpan _retryInterval;
         public TimeSpan Timeout { get; set; }
 
         public ThrowsSecondTimeQuery(T result, Options options)
@@ -95,24 +86,17 @@ namespace Coypu.Tests.When_making_browser_interactions_robust
             return result;
         }
 
-        public object ExpectedResult
-        {
-            get { return default(T); }
-        }
+        public object ExpectedResult => default(T);
 
         public int Tries { get; set; }
 
-        public TimeSpan RetryInterval
-        {
-            get { return _retryInterval; }
-        }
+        public TimeSpan RetryInterval { get; }
     }
 
     public class AlwaysThrowsQuery<TResult, TException> : Query<TResult> where TException : Exception
     {
         public Options Options { get; set; }
         public DriverScope Scope { get; private set; }
-        private readonly TimeSpan _retryInterval;
         private readonly Stopwatch stopWatch = new Stopwatch();
 
         public AlwaysThrowsQuery(Options options)
@@ -128,20 +112,14 @@ namespace Coypu.Tests.When_making_browser_interactions_robust
             throw (TException)Activator.CreateInstance(typeof(TException), "Test Exception");
         }
 
-        public object ExpectedResult
-        {
-            get { return default(TResult); }
-        }
+        public object ExpectedResult => default(TResult);
 
         public int Tries { get; set; }
         public long LastCall { get; set; }
 
         public TimeSpan Timeout { get; set; }
 
-        public TimeSpan RetryInterval
-        {
-            get { return _retryInterval; }
-        }
+        public TimeSpan RetryInterval { get; }
     }
 
     public class AlwaysThrowsPredicateQuery<TException> : PredicateQuery where TException : Exception
@@ -160,11 +138,6 @@ namespace Coypu.Tests.When_making_browser_interactions_robust
             throw (TException)Activator.CreateInstance(typeof(TException), "Test Exception");
         }
 
-        public bool ExpectedResult
-        {
-            get { return false; }
-        }
-
         public int Tries { get; set; }
         public long LastCall { get; set; }
 
@@ -178,8 +151,6 @@ namespace Coypu.Tests.When_making_browser_interactions_robust
         private readonly T actualResult;
         private readonly T expectedResult;
         private readonly int throwsHowManyTimes;
-        private readonly TimeSpan _timeout;
-        private readonly TimeSpan _retryInterval;
 
         public ThrowsThenSubsequentlySucceedsQuery(T actualResult, T expectedResult, int throwsHowManyTimes, Options options)
         {
@@ -201,31 +172,21 @@ namespace Coypu.Tests.When_making_browser_interactions_robust
             return actualResult;
         }
 
-        public object ExpectedResult
-        {
-            get { return expectedResult; }
-        }
+        public object ExpectedResult => expectedResult;
 
         public int Tries { get; set; }
         public long LastCall { get; set; }
 
 
-        public TimeSpan Timeout
-        {
-            get { return _timeout; }
-        }
+        public TimeSpan Timeout { get; }
 
-        public TimeSpan RetryInterval
-        {
-            get { return _retryInterval; }
-        }
+        public TimeSpan RetryInterval { get; }
     }
 
     public class ThrowsThenSubsequentlySucceedsPredicateQuery : PredicateQuery
     {
         private readonly Stopwatch stopWatch = new Stopwatch();
         private readonly bool actualResult;
-        private readonly bool expectedResult;
         private readonly int throwsHowManyTimes;
 
 
@@ -234,7 +195,7 @@ namespace Coypu.Tests.When_making_browser_interactions_robust
         {
             stopWatch.Start();
             this.actualResult = actualResult;
-            this.expectedResult = expectedResult;
+            this.ExpectedResult = expectedResult;
             this.throwsHowManyTimes = throwsHowManyTimes;
         }
 
@@ -252,10 +213,7 @@ namespace Coypu.Tests.When_making_browser_interactions_robust
             return actualResult;
         }
 
-        public bool ExpectedResult
-        {
-            get { return expectedResult; }
-        }
+        public new bool ExpectedResult { get; }
 
         public int Tries { get; set; }
         public long LastCall { get; set; }

--- a/src/Coypu.sln
+++ b/src/Coypu.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2037
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29009.5
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Coypu", "Coypu\Coypu.csproj", "{0495F7A7-A1A9-422C-BE9D-6D9F9BD4E97C}"
 EndProject

--- a/src/Coypu/Coypu.csproj
+++ b/src/Coypu/Coypu.csproj
@@ -5,17 +5,17 @@
     <BuildPackage>true</BuildPackage>
     <AssemblyTitle>Coypu</AssemblyTitle>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.1.0</FileVersion>
+    <FileVersion>3.1.0.0</FileVersion>
     <PackageId>Coypu</PackageId>
-    <Version>3.0.1</Version>
-    <Description>Intuitive, robust browser automation for .Net platform.
-This package includes the Coypu 3 framework assembly, which is referenced by your tests.
+    <Version>3.1.0-rc</Version>
+    <Description>Intuitive, robust browser automation for the .NET platform.
+This package includes the Coypu 3 framework assembly, which should be referenced by your tests.
 
 Supported platforms:
 - .NET Framework 4.5+
 - .NET Standard 2.0+
-- .NET Core 2.0</Description>
-    <PackageLicenseUrl>https://github.com/featurist/coypu/blob/master/LICENSE.txt</PackageLicenseUrl>
+- .NET Core 2.0+</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/featurist/coypu/</PackageProjectUrl>
     <Copyright>Copyright © 2018 Adrian Longley and Contributors</Copyright>
     <PackageTags>browser, automation, selenium, testing, framework</PackageTags>
@@ -23,8 +23,6 @@ Supported platforms:
     <Authors>Adrian Longley, Jakub Obstarczyk</Authors>
     <RepositoryUrl>https://github.com/featurist/coypu</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Product />
-    <PackageReleaseNotes>nuget package build from csproj</PackageReleaseNotes>
     <Company>Coypu</Company>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>

--- a/src/Coypu/Drivers/Selenium/FrameFinder.cs
+++ b/src/Coypu/Drivers/Selenium/FrameFinder.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Firefox;
 
 namespace Coypu.Drivers.Selenium
 {
@@ -69,6 +70,13 @@ namespace Coypu.Drivers.Selenium
             {
                 _selenium.SwitchTo()
                          .Window(currentHandle);
+
+                // Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1305822 
+                if (_selenium is FirefoxDriver)
+                {
+                    _selenium.SwitchTo()
+                        .DefaultContent();
+                }
             }
         }
     }

--- a/src/Coypu/Drivers/Selenium/SeleniumWindowManager.cs
+++ b/src/Coypu/Drivers/Selenium/SeleniumWindowManager.cs
@@ -34,15 +34,18 @@ namespace Coypu.Drivers.Selenium
 
         public void SwitchToWindow(string windowName)
         {
-            if (SwitchedToAFrame)
-            {
-                _webDriver.SwitchTo().DefaultContent();
-            }
+            // Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1305822 
+            var isFirefox = _webDriver is FirefoxDriver;
 
-            if (LastKnownWindowHandle != windowName)
+            if (LastKnownWindowHandle != windowName || !isFirefox && SwitchedToAFrame)
             {
                 _webDriver.SwitchTo().Window(windowName);
                 LastKnownWindowHandle = windowName;
+            }
+
+            if (isFirefox && SwitchedToAFrame)
+            {
+                _webDriver.SwitchTo().DefaultContent();
             }
 
             _switchedToFrame = null;

--- a/src/Coypu/Drivers/Selenium/SeleniumWindowManager.cs
+++ b/src/Coypu/Drivers/Selenium/SeleniumWindowManager.cs
@@ -26,13 +26,6 @@ namespace Coypu.Drivers.Selenium
             var frame = _webDriver.SwitchTo()
                                   .Frame(webElement);
 
-            // Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1305822 
-            if (_webDriver is FirefoxDriver)
-            {
-                _webDriver.SwitchTo()
-                    .DefaultContent();
-            }
-
             _switchedToFrameElement = webElement;
             _switchedToFrame = frame;
 
@@ -41,10 +34,14 @@ namespace Coypu.Drivers.Selenium
 
         public void SwitchToWindow(string windowName)
         {
-            if (LastKnownWindowHandle != windowName || SwitchedToAFrame)
+            if (SwitchedToAFrame)
             {
-                _webDriver.SwitchTo()
-                          .Window(windowName);
+                _webDriver.SwitchTo().DefaultContent();
+            }
+
+            if (LastKnownWindowHandle != windowName)
+            {
+                _webDriver.SwitchTo().Window(windowName);
                 LastKnownWindowHandle = windowName;
             }
 

--- a/src/Coypu/Drivers/Selenium/SeleniumWindowManager.cs
+++ b/src/Coypu/Drivers/Selenium/SeleniumWindowManager.cs
@@ -1,4 +1,5 @@
 ﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Firefox;
 
 namespace Coypu.Drivers.Selenium
 {
@@ -24,6 +25,13 @@ namespace Coypu.Drivers.Selenium
 
             var frame = _webDriver.SwitchTo()
                                   .Frame(webElement);
+
+            // Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1305822 
+            if (_webDriver is FirefoxDriver)
+            {
+                _webDriver.SwitchTo()
+                    .DefaultContent();
+            }
 
             _switchedToFrameElement = webElement;
             _switchedToFrame = frame;

--- a/src/Coypu/ElementScope.cs
+++ b/src/Coypu/ElementScope.cs
@@ -130,6 +130,7 @@ namespace Coypu
         ///     <para>Override the way Coypu is configured to find elements for this call only.</para>
         ///     <para>E.g. A longer wait:</para>
         ///     <returns>The current scope</returns>
+        /// </param>
         public ElementScope FillInWith(string value,
                                        Options options = null)
         {
@@ -145,6 +146,7 @@ namespace Coypu
         ///     <para>Override the way Coypu is configured to find elements for this call only.</para>
         ///     <para>E.g. A longer wait</para>
         ///     <returns>The current scope</returns>
+        /// </param>
         public ElementScope SelectOption(string value,
                                          Options options = null)
         {

--- a/src/Coypu/Options.cs
+++ b/src/Coypu/Options.cs
@@ -26,10 +26,9 @@ namespace Coypu
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
+            if (obj is null) return false;
+            return ReferenceEquals(this, obj) || Equals((Options) obj);
             //if (obj.GetType() != this.GetType()) return false;
-            return Equals((Options) obj);
         }
 
         /// <summary>

--- a/src/Coypu/Scope.cs
+++ b/src/Coypu/Scope.cs
@@ -282,6 +282,10 @@ namespace Coypu
         ///     otherwise this will return immediately.
         /// </summary>
         /// <param name="xpath">XPath query</param>
+        /// <param name="predicate">
+        ///     A predicate to test the entire collection against. It will wait for this predicate before
+        ///     returning a list of matching elements.
+        /// </param>
         /// <param name="options">
         ///     <para>Override the way Coypu is configured to find elements for this call only.</para>
         ///     <para>E.g. A longer wait:</para>
@@ -396,7 +400,7 @@ namespace Coypu
         /// <returns>An element</returns>
         ElementScope FindId(string id,
                             Options options = null);
-
+        /// <summary>
         /// ** For Asp.Net Web Forms ** Find the first matching element with id ending with the specified stringto appear within the configured timeout
         /// </summary>
         /// <param name="endsWith">Element id</param>

--- a/src/Coypu/Scope.cs
+++ b/src/Coypu/Scope.cs
@@ -12,6 +12,9 @@ namespace Coypu
     /// </summary>
     public interface Scope
     {
+        /// <summary>
+        /// The current browser window
+        /// </summary>
         Browser Browser { get; }
 
         /// <summary>
@@ -160,7 +163,7 @@ namespace Coypu
 
         /// <summary>
         ///     Query whether text does not appear on the page using a regular expression. Returns as soon as the text does not
-        ///     appear, or when the <see cref="SessionConfiguration.Timeout" /> is reached.
+        ///     appear, or when the <see cref="Options.Timeout" /> is reached.
         /// </summary>
         /// <param name="pattern">The regular expression expected not to match</param>
         /// <param name="options">
@@ -219,7 +222,6 @@ namespace Coypu
         ///     Find an element matching an XPath query
         /// </summary>
         /// <param name="xpath">XPath query</param>
-        /// <param name="text">The text of the element you are looking for</param>
         /// <param name="options">
         ///     <para>Override the way Coypu is configured to find elements for this call only.</para>
         ///     <para>E.g. A longer wait:</para>
@@ -240,7 +242,7 @@ namespace Coypu
         ///     <code>new Options{Timeout = TimeSpan.FromSeconds(60)}</code>
         /// </param>
         /// <returns>The first matching element</returns>
-        ElementScope FindXPath(string idInspectingcontentUlIdCsstestLi,
+        ElementScope FindXPath(string xpath,
                                string text,
                                Options options = null);
 
@@ -248,13 +250,14 @@ namespace Coypu
         ///     Find an element matching an XPath query
         /// </summary>
         /// <param name="xpath">XPath query</param>
+        /// <param name="text">The text of the element must match this pattern</param>
         /// <param name="options">
         ///     <para>Override the way Coypu is configured to find elements for this call only.</para>
         ///     <para>E.g. A longer wait:</para>
         ///     <code>new Options{Timeout = TimeSpan.FromSeconds(60)}</code>
         /// </param>
         /// <returns>The first matching element</returns>
-        ElementScope FindXPath(string idInspectingcontentUlIdCsstestLi,
+        ElementScope FindXPath(string xpath,
                                Regex text,
                                Options options = null);
 
@@ -457,10 +460,10 @@ namespace Coypu
 
         /// <summary>
         ///     <para>
-        ///         Retry an action on any exception until it succeeds. Once the <see cref="SessionConfiguration.Timeout" /> is
+        ///         Retry an action on any exception until it succeeds. Once the <see cref="Options.Timeout" /> is
         ///         passed any exception will be rethrown.
         ///     </para>
-        ///     <para>Waits for the <see cref="SessionConfiguration.RetryInterval" /> between retries</para>
+        ///     <para>Waits for the <see cref="Options.RetryInterval" /> between retries</para>
         /// </summary>
         /// <param name="action">An action</param>
         /// <param name="options">
@@ -473,25 +476,20 @@ namespace Coypu
 
         /// <summary>
         ///     <para>
-        ///         Retry an action on any exception until it succeeds. Once the <see cref="SessionConfiguration.Timeout" /> is
+        ///         Retry an action on any exception until it succeeds. Once the <see cref="Options.Timeout" /> is
         ///         passed any exception will be rethrown.
         ///     </para>
-        ///     <para>Waits for the <see cref="SessionConfiguration.RetryInterval" /> between retries</para>
+        ///     <para>Waits for the <see cref="Options.RetryInterval" /> between retries</para>
         /// </summary>
         /// <param name="action">An action</param>
-        /// <param name="options">
-        ///     <para>Override the way Coypu is configured to find elements for this call only.</para>
-        ///     <para>E.g. A longer wait:</para>
-        ///     <code>new Options{Timeout = TimeSpan.FromSeconds(60)}</code>
-        /// </param>
         void RetryUntilTimeout(BrowserAction action);
 
         /// <summary>
         ///     <para>
-        ///         Retry a function on any exception until it succeeds. Once the <see cref="SessionConfiguration.Timeout" /> is
+        ///         Retry a function on any exception until it succeeds. Once the <see cref="Options.Timeout" /> is
         ///         passed any exception will be rethrown.
         ///     </para>
-        ///     <para>Waits for the <see cref="SessionConfiguration.RetryInterval" /> between retries</para>
+        ///     <para>Waits for the <see cref="Options.RetryInterval" /> between retries</para>
         /// </summary>
         /// <param name="function">A function</param>
         /// <param name="options">
@@ -505,13 +503,13 @@ namespace Coypu
         /// <summary>
         ///     <para>
         ///         Execute a query repeatedly until either the expected result is returned or the
-        ///         <see cref="SessionConfiguration.Timeout" /> is passed.
+        ///         <see cref="Options.Timeout" /> is passed.
         ///     </para>
         ///     <para>
-        ///         Once the <see cref="SessionConfiguration.Timeout" /> is passed any result will be returned or any exception
+        ///         Once the <see cref="Options.Timeout" /> is passed any result will be returned or any exception
         ///         will be rethrown.
         ///     </para>
-        ///     <para>Waits for the <see cref="SessionConfiguration.RetryInterval" /> between retries.</para>
+        ///     <para>Waits for the <see cref="Options.RetryInterval" /> between retries.</para>
         /// </summary>
         /// <param name="query">A query</param>
         T Query<T>(Query<T> query);
@@ -519,13 +517,13 @@ namespace Coypu
         /// <summary>
         ///     <para>
         ///         Execute a query repeatedly until either the expected result is returned or the
-        ///         <see cref="SessionConfiguration.Timeout" /> is passed.
+        ///         <see cref="Options.Timeout" /> is passed.
         ///     </para>
         ///     <para>
-        ///         Once the <see cref="SessionConfiguration.Timeout" /> is passed any result will be returned or any exception
+        ///         Once the <see cref="Options.Timeout" /> is passed any result will be returned or any exception
         ///         will be rethrown.
         ///     </para>
-        ///     <para>Waits for the <see cref="SessionConfiguration.RetryInterval" /> between retries.</para>
+        ///     <para>Waits for the <see cref="Options.RetryInterval" /> between retries.</para>
         /// </summary>
         /// <param name="query">A query</param>
         /// <param name="expecting">Expected result</param>
@@ -544,7 +542,7 @@ namespace Coypu
         ///         Allows the time specified in <paramref name="waitBeforeRetry" /> for the <paramref name="until" /> condition
         ///         to be met before each retry.
         ///     </para>
-        ///     <para>Once the <see cref="SessionConfiguration.Timeout" /> is passed a Coypu.MissingHtmlException will be thrown.</para>
+        ///     <para>Once the <see cref="Options.Timeout" /> is passed a Coypu.MissingHtmlException will be thrown.</para>
         /// </summary>
         /// <param name="tryThis">The action to try</param>
         /// <param name="until">The condition to be met</param>
@@ -562,15 +560,10 @@ namespace Coypu
 
         /// <summary>
         ///     <para>Execute an action repeatedly until a condition is met.</para>
-        ///     <para>
-        ///         Allows the time specified in <paramref name="waitBeforeRetry" /> for the <paramref name="until" /> query to
-        ///         return the expected value before each retry.
-        ///     </para>
-        ///     <para>Once the <see cref="SessionConfiguration.Timeout" /> is passed a Coypu.MissingHtmlException will be thrown.</para>
+        ///     <para>Once the <see cref="Options.Timeout" /> is passed a Coypu.MissingHtmlException will be thrown.</para>
         /// </summary>
         /// <param name="tryThis">The action to try</param>
         /// <param name="until">The condition to be met</param>
-        /// <param name="waitBeforeRetry">How long to wait for the condition to be met before retrying</param>
         /// <param name="options">
         ///     <para>Override the way Coypu is configured to find elements for this call only.</para>
         ///     <para>E.g. A longer wait:</para>
@@ -628,7 +621,7 @@ namespace Coypu
         ///     <para>Click a button, input of type button|submit|image or div with the css class "button".</para>
         ///     <para>Wait for a condition to be satisfied for a specified time otherwise click and wait again.</para>
         ///     <para>
-        ///         Continues until the expected condition is satisfied or the <see cref="SessionConfiguration.Timeout" /> is
+        ///         Continues until the expected condition is satisfied or the <see cref="Options.Timeout" /> is
         ///         reached.
         ///     </para>
         /// </summary>
@@ -648,7 +641,7 @@ namespace Coypu
         /// <summary>
         ///     <para>Click a link and wait for a condition to be satisfied for a specified time otherwise click and wait again.</para>
         ///     <para>
-        ///         Continues until the expected condition is satisfied or the <see cref="SessionConfiguration.Timeout" /> is
+        ///         Continues until the expected condition is satisfied or the <see cref="Options.Timeout" /> is
         ///         reached.
         ///     </para>
         /// </summary>

--- a/src/Coypu/Scope.cs
+++ b/src/Coypu/Scope.cs
@@ -149,7 +149,7 @@ namespace Coypu
 
         /// <summary>
         ///     Query whether text does not appear on the page. Returns as soon as the text does not appear, or when the
-        ///     <see cref="SessionConfiguration.Timeout" /> is reached.
+        ///     <see cref="Options.Timeout" /> is reached.
         /// </summary>
         /// <param name="text">The exact text expected not to be found</param>
         /// <param name="options">

--- a/src/Coypu/SynchronisedElementScope.cs
+++ b/src/Coypu/SynchronisedElementScope.cs
@@ -25,7 +25,7 @@ namespace Coypu
         }
 
         /// <summary>
-        ///     <para>Check if this element exists within the <see cref="SessionConfiguration.Timeout" /></para>
+        ///     <para>Check if this element exists within the <see cref="Options.Timeout" /></para>
         /// </summary>
         /// <param name="options">
         ///     <para>Override the way Coypu is configured to find elements for this call only.</para>
@@ -38,7 +38,7 @@ namespace Coypu
         }
 
         /// <summary>
-        ///     <para>Check if this element becomes missing within the <see cref="SessionConfiguration.Timeout" /></para>
+        ///     <para>Check if this element becomes missing within the <see cref="Options.Timeout" /></para>
         /// </summary>
         /// <param name="options">
         ///     <para>Override the way Coypu is configured to find elements for this call only.</para>


### PR DESCRIPTION
- Fixes #205, have confirmed that the iframe tests are working again in firefox and the problem is fixed in my own projects. 

- Added missing Test.Sdk so VS Integration works correctly when running the test projects

- Fixed some broken XML docs

- General dependency update and Csproj cleanup (I'd suggest not using the nuget release note tag, it's a waste of time)



