### PR TITLE
Return QueryDescription on ElementFinder.ToString()

### DIFF
--- a/src/Coypu.Tests/When_interacting_with_the_browser/WhenFindingSingleElements.cs
+++ b/src/Coypu.Tests/When_interacting_with_the_browser/WhenFindingSingleElements.cs
@@ -47,6 +47,7 @@ namespace Coypu.Tests.When_interacting_with_the_browser
             Assert.That(scope.ElementFinder.Driver, Is.EqualTo(Driver));
             Assert.That(scope.ElementFinder.Locator, Is.EqualTo("Some locator"));
             Assert.That(scope.ElementFinder.Options, Is.EqualTo(Options.Merge(options, SessionConfiguration)));
+            Assert.That(scope.ElementFinder.ToString(), Is.EqualTo(scope.ElementFinder.QueryDescription));
         }
 
         [Test]

--- a/src/Coypu/Finders/ElementFinder.cs
+++ b/src/Coypu/Finders/ElementFinder.cs
@@ -36,6 +36,11 @@ namespace Coypu.Finders
         {
             return new SynchronisedElementScope(this, Scope, Options);
         }
+
+        public override string ToString()
+        {
+            return QueryDescription;
+        }
     }
 
 }


### PR DESCRIPTION
Currently Coypu makes nice error messages using the internal property QueryDescrption. It would be useful if this were available publicly so that it could be used when writing test error messages externally.

Would it be acceptable to override `ToString` to use this property on the base class?

(I'm asuming that this is an internal property to limit the API surface so that it doesn't need to be supported in future)
