### PR TITLE
Fix ConsiderInvisibleElements comment

### DIFF
--- a/src/Coypu/Options.cs
+++ b/src/Coypu/Options.cs
@@ -135,7 +135,7 @@ namespace Coypu
 
         /// <summary>
         /// <para>By default Coypu will exclude any invisible elements, this allows you to override that behaviour</para>
-        /// <para>Default: true</para>
+        /// <para>Default: false</para>
         /// </summary>
         public bool ConsiderInvisibleElements
         {


### PR DESCRIPTION
The default for ConsiderInvisibleElements is false, as specified by the DEFAULT_CONSIDER_INVISIBLE_ELEMENTS field.