### PR TITLE
Fixes tests which fail when run in isolation

### DIFF
--- a/src/Coypu.Tests/When_interacting_with_the_browser/When_finding_state.cs
+++ b/src/Coypu.Tests/When_interacting_with_the_browser/When_finding_state.cs
@@ -12,10 +12,14 @@ namespace Coypu.Tests.When_interacting_with_the_browser
     [TestFixture]
     public class When_finding_state
     {
+        [SetUp]
+        public void SetUp()
+        {
+            SessionConfiguration = new SessionConfiguration();
+        }
 
         internal BrowserSession BuildSession(TimingStrategy timingStrategy)
         {
-            SessionConfiguration = new SessionConfiguration();
             return TestSessionBuilder.Build(SessionConfiguration,new FakeDriver(), timingStrategy, new FakeWaiter(), null, null);
         }
 


### PR DESCRIPTION
The following tests would fail with a null reference if they were run on their own:
* `It_returns_the_state_that_was_found_first_Example_1()`
* `It_returns_the_state_that_was_found_first_Example_2()`
* `It_returns_the_state_that_was_found_first_Example_3()`
* `When_query_returns_false_It_raises_an_exception()`

This is because `SessionConfiguration` is used early on in the tests, but it isn't initialised until `BuildSession()` is called later. When run in combination with other tests, they pass by chance, depending which other test has run before it, as in that case the `SessionConfiguration` is then initialised by another test. 

I've added a `SetUp` method to ensure a fresh `SessionConfiguration` each test (it always uses a default one anyway). Alternatively we could swap around the order of the lines in these tests so that `var session = BuildSession(....)` comes before `var state1 = ....`