### PR TITLE
Fix return type of ExecuteScript for Playwright; Add generic overload

### DIFF
--- a/src/Coypu.Drivers.Tests/When_executing_script.cs
+++ b/src/Coypu.Drivers.Tests/When_executing_script.cs
@@ -1,6 +1,8 @@
 ﻿using Coypu.Finders;
 using Shouldly;
 using NUnit.Framework;
+using System;
+using Coypu.Tests;
 
 namespace Coypu.Drivers.Tests
 {
@@ -30,6 +32,27 @@ namespace Coypu.Drivers.Tests
         public void Returns_the_result()
         {
             Driver.ExecuteScript("return document.getElementById('firstButtonId').innerHTML;", Root).ShouldBe("first button");
+            Driver.ExecuteScript("return 1234;", Root).ShouldBe(1234);
+        }
+
+         [Test]
+        public void Returns_the_result_typed()
+        {
+            string str = Driver.ExecuteScript<string>("return 'miles';", Root);
+            str.GetType().ShouldBe(typeof(string));
+
+            int integer = Driver.ExecuteScript<int>("return 1234;", Root);
+            integer.GetType().ShouldBe(typeof(int));
+
+            DateTime dateTime = Driver.ExecuteScript<DateTime>("return new Date();", Root);
+            dateTime.GetType().ShouldBe(typeof(DateTime));
+
+            try {
+              Driver.ExecuteScript<int>("return 'bob';", Root);
+              throw new TestException("Expected an exception");
+            } catch(Exception e) {
+              if (e is TestException) throw;
+            };
         }
     }
 }

--- a/src/Coypu.Tests/TestDoubles/FakeDriver.cs
+++ b/src/Coypu.Tests/TestDoubles/FakeDriver.cs
@@ -113,7 +113,14 @@ namespace Coypu.Tests.TestDoubles
                                     Scope scope,
                                     params object[] args)
         {
-            return Find<string>(_stubbedExecuteScriptResults, javascript, scope);
+            return ExecuteScript<string>(javascript, scope, args);
+        }
+
+        public ReturnType ExecuteScript<ReturnType>(string javascript,
+                                    Scope scope,
+                                    params object[] args)
+        {
+            return Find<ReturnType>(_stubbedExecuteScriptResults, javascript, scope);
         }
 
         public IEnumerable<Element> FindFrames(string locator,

--- a/src/Coypu.Tests/TestDoubles/StubDriver.cs
+++ b/src/Coypu.Tests/TestDoubles/StubDriver.cs
@@ -87,6 +87,13 @@ namespace Coypu.Tests.TestDoubles
             return null;
         }
 
+        public ReturnType ExecuteScript<ReturnType>(string javascript,
+                                    Scope scope,
+                                    params object[] args)
+        {
+            return default;
+        }
+
         public void Hover(Element element) { }
 
         public IEnumerable<Cookie> GetBrowserCookies()

--- a/src/Coypu/Drivers/Playwright/PlaywrightDriver.cs
+++ b/src/Coypu/Drivers/Playwright/PlaywrightDriver.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Cookie = System.Net.Cookie;
 using Microsoft.Playwright;
+using OpenQA.Selenium.DevTools.V85.Network;
 
 #pragma warning disable 1591
 
@@ -350,11 +351,17 @@ namespace Coypu.Drivers.Playwright
                                     Scope scope,
                                     params object[] args)
         {
+            return ExecuteScript<object>(javascript, scope, args);
+        }
+
+        public ReturnType ExecuteScript<ReturnType>(string javascript,
+                                    Scope scope,
+                                    params object[] args)
+        {
             var func = $"(arguments) => {Regex.Replace(javascript, "^return ", string.Empty)}";
             return
               PlaywrightPage(scope)
-                .EvaluateAsync(func, ConvertScriptArgs(args)).Sync()
-                .ToString();
+                .EvaluateAsync<ReturnType>(func, ConvertScriptArgs(args)).Sync();
         }
 
         // TODO: extract duplication between Drivers

--- a/src/Coypu/Drivers/Selenium/SeleniumWebDriver.cs
+++ b/src/Coypu/Drivers/Selenium/SeleniumWebDriver.cs
@@ -243,11 +243,17 @@ namespace Coypu.Drivers.Selenium
                                     Scope scope,
                                     params object[] args)
         {
+            return ExecuteScript<object>(javascript, scope, args);
+        }
+        public ReturnType ExecuteScript<ReturnType>(string javascript,
+                                    Scope scope,
+                                    params object[] args)
+        {
             if (NoJavascript)
                 throw new NotSupportedException("Javascript is not supported by " + _browser);
 
             _elementFinder.SeleniumScope(scope);
-            return JavaScriptExecutor.ExecuteScript(javascript, ConvertScriptArgs(args));
+            return (ReturnType) JavaScriptExecutor.ExecuteScript(javascript, ConvertScriptArgs(args));
         }
 
         public void Dispose()

--- a/src/Coypu/IDriver.cs
+++ b/src/Coypu/IDriver.cs
@@ -22,6 +22,8 @@ namespace Coypu
         String Title(Scope scope);
         object ExecuteScript(string javascript, Scope scope, params object[] args);
 
+        ReturnType ExecuteScript<ReturnType>(string javascript, Scope scope, params object[] args);
+
         [Obsolete("Please use instead: _browserSession.Driver.Cookies.GetAll()")]
         IEnumerable<Cookie> GetBrowserCookies();
 


### PR DESCRIPTION
Use Playwrights generic API to evaluate javascript, this has the same behaviour as Selenium in that the return value is of the inferred type, e.g. string, int, DateTime etc

Added a generic overload to the Coypu Driver API to make this a bit more friendly for all drivers.

Part of #232 

